### PR TITLE
Grabbing non HTMLified text

### DIFF
--- a/assets/plugin.js
+++ b/assets/plugin.js
@@ -1,7 +1,7 @@
 require(["gitbook", "jQuery"], function(gitbook, $) {
     function bindNotebook() {
         var $pre = $(this);
-        var source = $pre.html();
+        var source = $pre.text();
         var readOnly = $pre.hasClass('readonly');
 
         var $div = $('<div>');


### PR DESCRIPTION
`$pre.html()` will use the HTMLified version of the JavaScript code, so, for instance,  `1 <  2` will be inserted into the `$div` as `1 &gt; 2`. `$pre.text()` will be sure to grab the true text representation.
