### PR TITLE
Constructing the pre

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ module.exports = {
         tonic: {
             process: function(block) {
                 var readOnly = Boolean(block.kwargs.readOnly);
-                var nodeVersion = '';
                 var pre = window.document.createElement('pre');
                 if (block.kwargs.nodeVersion) {
                   pre['data-node-version'] = block.kwargs.nodeVersion;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var jsdom = require("jsdom").jsdom;
 var window = jsdom().defaultView;
+var he = require('he');
 
 module.exports = {
     book: {
@@ -20,7 +21,7 @@ module.exports = {
                 var className = 'pg-tonic';
                 if (readOnly) className += ' readonly';
 
-                pre.textContent = block.body;
+                pre.textContent = he.decode(block.body).replace(/\\/g, '');
                 pre.className += className;
                 return pre.outerHTML;
             }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var jsdom = require("jsdom").jsdom;
+var window = jsdom().defaultView;
 
 module.exports = {
     book: {
@@ -11,10 +13,17 @@ module.exports = {
         tonic: {
             process: function(block) {
                 var readOnly = Boolean(block.kwargs.readOnly);
+                var nodeVersion = '';
+                var pre = window.document.createElement('pre');
+                if (block.kwargs.nodeVersion) {
+                  pre['data-node-version'] = block.kwargs.nodeVersion;
+                }
                 var className = 'pg-tonic';
                 if (readOnly) className += ' readonly';
 
-                return '<pre class="' + className + '">' + block.body + '</pre>';
+                pre.textContent = block.body;
+                pre.className += className;
+                return pre.outerHTML;
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gitbook-plugin-tonic",
   "description": "Embed tonic notebook into your book",
   "main": "index.js",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "engines": {
     "gitbook": ">=2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "https://github.com/GitbookIO/plugin-tonic/issues"
   },
   "dependencies": {
+    "he": "^1.1.0",
     "jsdom": "^9.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gitbook-plugin-tonic",
   "description": "Embed tonic notebook into your book",
   "main": "index.js",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "engines": {
     "gitbook": ">=2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gitbook-plugin-tonic",
   "description": "Embed tonic notebook into your book",
   "main": "index.js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "engines": {
     "gitbook": ">=2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,18 +1,21 @@
 {
-    "name": "gitbook-plugin-tonic",
-    "description": "Embed tonic notebook into your book",
-    "main": "index.js",
-    "version": "1.0.0",
-    "engines": {
-        "gitbook": ">=2.0.0"
-    },
-    "homepage": "https://github.com/GitbookIO/plugin-tonic",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/GitbookIO/plugin-tonic.git"
-    },
-    "license": "Apache-2.0",
-    "bugs": {
-        "url": "https://github.com/GitbookIO/plugin-tonic/issues"
-    }
+  "name": "gitbook-plugin-tonic",
+  "description": "Embed tonic notebook into your book",
+  "main": "index.js",
+  "version": "1.0.0",
+  "engines": {
+    "gitbook": ">=2.0.0"
+  },
+  "homepage": "https://github.com/GitbookIO/plugin-tonic",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GitbookIO/plugin-tonic.git"
+  },
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/GitbookIO/plugin-tonic/issues"
+  },
+  "dependencies": {
+    "jsdom": "^9.4.1"
+  }
 }


### PR DESCRIPTION
The current implementation to build the `pre` element will do some funny things, like add `=""` after newlines, parenthesis, and brackets, etc. This brings in `jsdom`, not a lite library but it helped me build valid elements and get around some of the issues. Open to any comments.

Here's the bit of code that first exposed the issue(s).

``` javascript
var year = 1975;
var fashion;

if (year >= 1960 && year <= 1969) {
  fashion = 'Bell Bottoms';
} else if (year >= 1970 && year <= 1979) {
  fashion = 'Afros and Lip Gloss';
} else if (year >= 1980 && year <= 1989) {
  fashion = 'Shoulder Pads and Bangle Bracelets';
} else if (year >= 1990 && year <= 1999) {
  fashion = 'Wallet Chains';
} else {
  fashion = 'T-shirts and skinny jeans';
}

console.log(fashion);
```

would insert

``` javascript
var year = 1975;
var fashion;

if (year >= 1960 && year <= 1969)="" {="" fashion="Bell Bottoms" ;="" }="" else="" if="" (year="">= 1970 && year <= 1979)="" {="" fashion="Afros and Lip Gloss" ;="" }="" else="" if="" (year="">= 1980 && year <= 1989)="" {="" fashion="Shoulder Pads and Bangle Bracelets" ;="" }="" else="" if="" (year="">= 1990 && year <= 1999)="" {="" fashion="Wallet Chains" ;="" }="" else="" console.log(fashion);="" <="" pre="">
```

into the plugin.
